### PR TITLE
Pyenv: Provides Python 2 and 3

### DIFF
--- a/scripts/provisioning/python.sh
+++ b/scripts/provisioning/python.sh
@@ -14,8 +14,8 @@ eval "\$(pyenv init -)"
 eval "\$(pyenv virtualenv-init -)"
 EOF
 
-su ${SSH_USER} <<EOF
 echo "==> Installing Pyenv"
+su ${SSH_USER} <<EOF
 curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
 source ~/.bashrc
 /home/${SSH_USER}/.pyenv/bin/pyenv install 2.7.9

--- a/scripts/provisioning/python.sh
+++ b/scripts/provisioning/python.sh
@@ -2,17 +2,17 @@
 
 SSH_USER=${SSH_USERNAME:-vagrant}
 
-export HOME=/home/${SSH_USER}
-
 echo "==> Installing Pyenv build tools"
 # From https://github.com/yyuu/pyenv/wiki/Common-build-problems
 sudo apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
 libreadline-dev libsqlite3-dev wget curl llvm
 
 echo "==> Preparing Pyenv configuration."
-echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> /home/${SSH_USER}/.bashrc
-echo 'eval "$(pyenv init -)"' >> /home/${SSH_USER}/.bashrc
-echo 'eval "$(pyenv virtualenv-init -)"' >> /home/${SSH_USER}/.bashrc
+cat <<EOF >> /home/${SSH_USER}/.bashrc
+export PATH="$HOME/.pyenv/bin:$PATH"
+eval "\$(pyenv init -)"
+eval "\$(pyenv virtualenv-init -)"
+EOF
 
 su ${SSH_USER} <<EOF
 echo "==> Installing Pyenv"

--- a/scripts/provisioning/python.sh
+++ b/scripts/provisioning/python.sh
@@ -4,26 +4,23 @@ SSH_USER=${SSH_USERNAME:-vagrant}
 
 export HOME=/home/${SSH_USER}
 
-echo "==> Installing Python 2.7"
-sudo add-apt-repository -y ppa:fkrull/deadsnakes
-sudo apt-get update
-sudo apt-get install -y python python-dev
+echo "==> Installing Pyenv build tools"
+# From https://github.com/yyuu/pyenv/wiki/Common-build-problems
+sudo apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
+libreadline-dev libsqlite3-dev wget curl llvm
 
-echo "==> Installing setuptools"
-sudo wget https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py
-sudo python ez_setup.py
-rm ez_setup.py setuptools-*
+echo "==> Preparing Pyenv configuration."
+echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> /home/${SSH_USER}/.bashrc
+echo 'eval "$(pyenv init -)"' >> /home/${SSH_USER}/.bashrc
+echo 'eval "$(pyenv virtualenv-init -)"' /home/${SSH_USER}/.bashrc
 
-echo "==> Installing pip"
-sudo easy_install pip
+su ${SSH_USER} <<EOF
+echo "==> Installing Pyenv"
+curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
+source ~/.bashrc
+env PATH=/home/vagrant/.pyenv/bin:$PATH pyenv install 2.7.9
+env PATH=/home/vagrant/.pyenv/bin:$PATH pyenv install 3.4.3
+env PATH=/home/vagrant/.pyenv/bin:$PATH pyenv global 2.7.9
+EOF
 
-echo "==> Installing virtualenvwrapper"
-sudo pip install virtualenvwrapper
-
-echo "==> Configuring virtualenvwrapper"
-mkdir -p ${HOME}/.virtualenvs
-echo "WORKON_HOME=${HOME}/.virtualenvs" >> ${HOME}/.bashrc
-echo "source /usr/local/bin/virtualenvwrapper.sh" >> ${HOME}/.bashrc
-
-chown -R ${SSH_USER}:${SSH_USER} ${HOME}/.virtualenvs
-export HOME=/home/root
+chown -R ${SSH_USER}:${SSH_USER} /home/${SSH_USER}

--- a/scripts/provisioning/python.sh
+++ b/scripts/provisioning/python.sh
@@ -18,9 +18,11 @@ su ${SSH_USER} <<EOF
 echo "==> Installing Pyenv"
 curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
 source ~/.bashrc
-env PATH=/home/vagrant/.pyenv/bin:$PATH pyenv install 2.7.9
-env PATH=/home/vagrant/.pyenv/bin:$PATH pyenv install 3.4.3
-env PATH=/home/vagrant/.pyenv/bin:$PATH pyenv global 2.7.9
 EOF
+
+export PYENV_ROOT=/home/${SSH_USER}/.pyenv
+/home/${SSH_USER}/.pyenv/bin/pyenv install 2.7.9
+/home/${SSH_USER}/.pyenv/bin/pyenv install 3.4.3
+/home/${SSH_USER}/.pyenv/bin/pyenv global 2.7.9
 
 chown -R ${SSH_USER}:${SSH_USER} /home/${SSH_USER}

--- a/scripts/provisioning/python.sh
+++ b/scripts/provisioning/python.sh
@@ -18,11 +18,9 @@ su ${SSH_USER} <<EOF
 echo "==> Installing Pyenv"
 curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
 source ~/.bashrc
-EOF
-
-export PYENV_ROOT=/home/${SSH_USER}/.pyenv
 /home/${SSH_USER}/.pyenv/bin/pyenv install 2.7.9
 /home/${SSH_USER}/.pyenv/bin/pyenv install 3.4.3
 /home/${SSH_USER}/.pyenv/bin/pyenv global 2.7.9
+EOF
 
 chown -R ${SSH_USER}:${SSH_USER} /home/${SSH_USER}

--- a/scripts/provisioning/python.sh
+++ b/scripts/provisioning/python.sh
@@ -2,6 +2,8 @@
 
 SSH_USER=${SSH_USERNAME:-vagrant}
 
+export HOME=/home/${SSH_USER}
+
 echo "==> Installing Pyenv build tools"
 # From https://github.com/yyuu/pyenv/wiki/Common-build-problems
 sudo apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \

--- a/scripts/provisioning/python.sh
+++ b/scripts/provisioning/python.sh
@@ -12,7 +12,7 @@ libreadline-dev libsqlite3-dev wget curl llvm
 echo "==> Preparing Pyenv configuration."
 echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> /home/${SSH_USER}/.bashrc
 echo 'eval "$(pyenv init -)"' >> /home/${SSH_USER}/.bashrc
-echo 'eval "$(pyenv virtualenv-init -)"' /home/${SSH_USER}/.bashrc
+echo 'eval "$(pyenv virtualenv-init -)"' >> /home/${SSH_USER}/.bashrc
 
 su ${SSH_USER} <<EOF
 echo "==> Installing Pyenv"

--- a/scripts/provisioning/python.sh
+++ b/scripts/provisioning/python.sh
@@ -11,7 +11,7 @@ libreadline-dev libsqlite3-dev wget curl llvm
 
 echo "==> Preparing Pyenv configuration."
 cat <<EOF >> /home/${SSH_USER}/.bashrc
-export PATH="$HOME/.pyenv/bin:$PATH"
+export PATH="\$HOME/.pyenv/bin:\$PATH"
 eval "\$(pyenv init -)"
 eval "\$(pyenv virtualenv-init -)"
 EOF


### PR DESCRIPTION
Usage is the same as a typical `pyenv` installation.

Addressing the concerns in #24, which means this Closes #24.

`pyenv`'s virtualenv plugin is also installed through `pyenv`'s installation script. See [yyuu/pyenv-virtualenv](https://github.com/yyuu/pyenv-virtualenv) for usage details. It's more than adequate to provide a Python virtual environment and as a `*env` family of tools user, I find it natural and nicely integrated. It's not `virtualenvwrapper` but it'll do just fine. Someone else can go make a PR for pyenv's `virtualenvwrapper` plugin if they really want to.

Closes #18. Provides Python 2 and Python 3.
